### PR TITLE
Delivery trip and Ts driver delivery trip fixes

### DIFF
--- a/sks/driver/doctype/ts_driver_delivery_trip/ts_driver_delivery_trip.js
+++ b/sks/driver/doctype/ts_driver_delivery_trip/ts_driver_delivery_trip.js
@@ -90,10 +90,10 @@ frappe.ui.form.on("TS Invoice Delivery Trip",{
 			await frappe.db.get_doc('Customer',data.customer,'is_credit_customer' ).then( (is_credit) => {
 				if (is_credit.is_credit_customer == 0){
 					if(data.amount > data.dis_amount){
-						frappe.throw("Paid Amount is more than Amount")
+						frappe.throw({title: "Message", message: "Paid Amount is more than Amount"})
 					}
 					else if (data.amount != data.dis_amount){
-						frappe.throw("The Customer is not credit customer")
+						frappe.throw({title: "Message", message: "The Customer is not credit customer"})
 					}
 				} 
 			} )

--- a/sks/driver/doctype/ts_driver_delivery_trip/ts_driver_delivery_trip.js
+++ b/sks/driver/doctype/ts_driver_delivery_trip/ts_driver_delivery_trip.js
@@ -75,7 +75,7 @@ frappe.ui.form.on("TS Invoice Delivery Trip",{
 				{fieldname: 'reason',label: 'Reason',fieldtype: 'Link', default:reason, options : 'Reason'},
 				{fieldtype:'Column Break'},
 				{fieldname: 'file_attachment',label: 'File Attach',fieldtype: 'Attach Image', default:p.file_attachment},
-				{fieldtype:'Section Break'},
+				{fieldtype:'Section Break', depends_on: "eval:doc.delivery_status == 'Delivered' "},
 				{fieldname: 'mode_of_payment',label: 'Mode of Payment',fieldtype: 'Link',options: 'Mode of Payment',default: 'Cash'},
 				{fieldtype:'Column Break'},
 				{fieldname: 'amount',label: 'Paid Amount',fieldtype: 'Currency'},
@@ -85,7 +85,18 @@ frappe.ui.form.on("TS Invoice Delivery Trip",{
 	
 			],
 			primary_action_label: "Update Invoice",
-			primary_action: function(data){
+			primary_action:async function(data){
+
+			await frappe.db.get_doc('Customer',data.customer,'is_credit_customer' ).then( (is_credit) => {
+				if (is_credit.is_credit_customer == 0){
+					if(data.amount > data.dis_amount){
+						frappe.throw("Paid Amount is more than Amount")
+					}
+					else if (data.amount != data.dis_amount){
+						frappe.throw("The Customer is not credit customer")
+					}
+				} 
+			} )
 		
 			if(data.mode_of_payment && data.amount && data.sales_invoice && data.delivery_status == "Delivered"){
 				frappe.call({

--- a/sks/sks/custom/js/delivery_trip.js
+++ b/sks/sks/custom/js/delivery_trip.js
@@ -15,7 +15,7 @@ frappe.ui.form.on('Delivery Trip',{
                         title: "Choose Invoices For Delivery 🛻🛻🛻🛻..",
                         fields: [
                             {label:'Delivery Day',fieldname:'sec',fieldtype:'Section Break'},
-                            {label:'Day',fieldname:'day',fieldtype:'Select', options:'\nSunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday'},
+                            {label:'Day',fieldname:'day',fieldtype:'Select', options:'\nSunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday', reqd: 1},
                             {label:'Select territory',fieldname:'sec1',fieldtype:'Section Break'},
                             {label:'Territory',fieldname:'territory',fieldtype: 'MultiSelectPills',
                             get_data: function() {
@@ -70,7 +70,7 @@ frappe.ui.form.on('Delivery Trip',{
                 }
             })
             
-        }).addClass('btn-danger')
+        }).addClass('btn-danger').css({'color':'white','background-color':'orange', 'font-weight': 'bold'});
     }
     },
     update_invoice: function(frm,cdt,cdn){


### PR DESCRIPTION
Fixes done:

1. "Get from sales invoice" button color changed to orange in delivery trip.
**Screenshot:**
![Screenshot from 2022-07-11 18-16-40](https://user-images.githubusercontent.com/95607390/178267495-1dc8ecc1-169d-49dd-ab2d-e1632f6afd88.png)

2. In the "Get from sales invoice" button dialogue box, the select field day has been made mandatory.
**Screenshot:**
![Screenshot from 2022-07-11 18-18-20](https://user-images.githubusercontent.com/95607390/178267760-2598c595-ee9b-4758-943d-206bab80beb5.png)
![Screenshot from 2022-07-11 18-18-44](https://user-images.githubusercontent.com/95607390/178267804-4bd126c1-f017-4c13-bc62-c2906d7f0d31.png)

3. In TS driver delivery trip, If delivery status == Delivered then display the fields:
-  Mode of payment
- Paid amount
- Time of Delivery
**Screenshot:**
![Screenshot from 2022-07-11 18-19-20](https://user-images.githubusercontent.com/95607390/178267968-837a4f2f-11ed-4c47-a670-ccc8c6f766e7.png)
![Screenshot from 2022-07-11 18-19-29](https://user-images.githubusercontent.com/95607390/178267982-80b79a58-66c5-4167-9d7e-7034d0fe60d6.png)


4. In Ts driver delivery trip, Partial payment accepted only if Customer has credit customer checked
**Screenshot:**
![Screenshot from 2022-07-11 18-20-55](https://user-images.githubusercontent.com/95607390/178268216-0f4fd966-a34e-409c-b52f-d5d19b9009ba.png)
![Screenshot from 2022-07-11 18-21-18](https://user-images.githubusercontent.com/95607390/178268287-13d41e21-5464-430e-9d43-7cdde1cac03f.png)
